### PR TITLE
RDKBDEV-2670: drop dependency on dbus

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,6 @@ dnl Checks for library functions.
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([memset strdup strerror])
 
-PKG_CHECK_MODULES([DBUS],[dbus-1 >= 1.6.18])
-
 AC_CONFIG_FILES([Makefile
 		source/Makefile])
 AC_OUTPUT

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -21,6 +21,6 @@
 
 bin_PROGRAMS = ipoe_health_check
 
-ipoe_health_check_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(DBUS_CFLAGS) $(SYSTEMD_CFLAGS)
+ipoe_health_check_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(SYSTEMD_CFLAGS)
 ipoe_health_check_SOURCES = ihc_core.c ihc_main.c
 ipoe_health_check_LDFLAGS = -lccsp_common -lrdkloggers -lnanomsg -lsysevent


### PR DESCRIPTION
Reason for change:
Code Cleanup.
Test Procedure: Sanity.
Risks: None.