### PR TITLE
RDKB-58019 : Adding version log.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,12 @@ m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])],
 
 
 
+#Add git version
+m4_define([GITVERSION],
+  m4_esyscmd_s([git describe --tags --always --dirty 2>/dev/null || echo "undefined"])
+)
+AC_SUBST([GIT_VERSION], [GITVERSION])
+
 
 dnl **********************************
 dnl checks for dependencies

--- a/source/Makefile.am
+++ b/source/Makefile.am
@@ -24,3 +24,4 @@ bin_PROGRAMS = ipoe_health_check
 ipoe_health_check_CFLAGS = -DFEATURE_SUPPORT_RDKLOG $(SYSTEMD_CFLAGS)
 ipoe_health_check_SOURCES = ihc_core.c ihc_main.c
 ipoe_health_check_LDFLAGS = -lccsp_common -lrdkloggers -lnanomsg -lsysevent
+ipoe_health_check_CFLAGS +=  -DGIT_VERSION=\"$(GIT_VERSION)\"

--- a/source/ihc_main.c
+++ b/source/ihc_main.c
@@ -65,6 +65,7 @@ int main(int argc, char *argv[])
     /* Initialize RDK Logger. */
     LOGInit();
 #endif //FEATURE_SUPPORT_RDKLOG
+    IhcInfo("Version : %s \n",GIT_VERSION );
 
     while ((c = getopt (argc, argv, "i:")) != -1)
         switch (c)


### PR DESCRIPTION
Reason for change:  Adding version log using "git describe --tags --always --dirty" command Example :
RC2.7.0a-1-g5aa0583-dirty
Tag: RC2.7.0a (Most recent tag)
Number of Commits Ahead: -1 (1 commit after the tag) Commit Hash: g5aa0583 ( "5aa0583" Hash of the current commit) Uncommitted Changes: -dirty (Changes not yet committed)

Test Procedure:
Version log should be present.

Priority: P1
Risks: none