### PR TITLE
RDKB-58521 : WAN Manager Telemetry Markers 2.0 - Phase 1

### DIFF
--- a/source/ihc_core.c
+++ b/source/ihc_core.c
@@ -1628,7 +1628,11 @@ int ihc_echo_handler(void)
                                 }
                                 else
                                 {
-                                    IhcError("IHC_V4_IDLE :: IHC: IPOE health check(IPv4) IDLE");
+		                    IhcInfo("[%s:%d] Sending IPOE_MSG_IHC_ECHO_IPV4_IDLE", __FUNCTION__, __LINE__);
+				    if (ihc_broadcastEvent(IPOE_MSG_IHC_ECHO_IPV4_IDLE) != IHC_SUCCESS)
+                                    {
+			                IhcError("IHC_V4_IDLE :: IHC: IPOE health check(IPv4) IDLE");
+				    }
                                 }
                             }
                             ihc_stop_echo_packets(IHC_ECHO_TYPE_V4);
@@ -1760,7 +1764,12 @@ int ihc_echo_handler(void)
                                 }
                                 else
                                 {
-                                    IhcError("IHC_V6_IDLE :: IHC: IPOE health check(IPv6) IDLE");
+                                    IhcInfo("[%s:%d] Sending IPOE_MSG_IHC_ECHO_IPV6_IDLE", __FUNCTION__, __LINE__);
+                                    if (ihc_broadcastEvent(IPOE_MSG_IHC_ECHO_IPV6_IDLE) != IHC_SUCCESS)
+                                    {
+                                        IhcError("IHC_V6_IDLE :: IHC: IPOE health check(IPv6) IDLE");
+                                    }
+
                                 }
                             }
                             ihc_stop_echo_packets(IHC_ECHO_TYPE_V6);


### PR DESCRIPTION
Reason for change: Implementing Telemetry support for Wanmanager.
Scalable to handle further telemetry versions

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1